### PR TITLE
feat: vite compatibility

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ function ignore(list, options = {}) {
       return importee === emptyFileName ||
         list.includes(importee) ||
         (options.commonjsBugFix &&
-          list.includes(importee.replace(/^\0/, "").replace(/\?commonjs-proxy$/, "")))
+          list.includes(importee.replace(/^\0/, "").replace(/\?(commonjs-proxy|commonjs-require)$/, "")))
         ? emptyFileName
         : null
     },


### PR DESCRIPTION
Build with [vite](https://vitejs.dev) unobviously adds ?commonjs-require suffix to files.
Found this problem while trying to exclude import of moment.js by chart.js. Without this feature importee stays in bundle.